### PR TITLE
Docs: Update Sparse Merkle Tree base case specification to use default value

### DIFF
--- a/src/specs/data_structures.md
+++ b/src/specs/data_structures.md
@@ -377,11 +377,13 @@ Nodes contain a single field:
 |------|---------------------------|-------------|
 | `v`  | [HashDigest](#hashdigest) | Node value. |
 
-The base case (an empty tree) is defined as the [hash](#hashing) of the empty string:
+The base case (an empty tree) is defined as the default value:
 
 ```C++
-node.v = 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+node.v = 0x0000000000000000000000000000000000000000000000000000000000000000
 ```
+
+Note that this is in contrast to the base case of the binary Merkle tree, where the root is the hash of the empty string. In the base case, a sparse Merkle tree is composed of default value leaves. Nodes containing only default value children have the default value as well. Applying these rules recursively percolates the default value up to the tree's root.  
 
 For leaf node `node` of leaf data `d` with key `k`:
 


### PR DESCRIPTION
Related issue: 
- https://github.com/celestiaorg/smt/issues/67

As per the discussion in the linked issue, the agreed upon change is that the root of an empty Sparse Merkle tree (the base case) is the _default value_, rather than the hash of the empty string. The default value, as per the spec, is the 32 byte 0: `0x0000000000000000000000000000000000000000000000000000000000000000`. This PR updates the specification to reflect the correct root in the SMT specification, and provides a short explanation on why this differs from the empty string root. 